### PR TITLE
Fix incorrect typespec

### DIFF
--- a/lib/emojix/emoji.ex
+++ b/lib/emojix/emoji.ex
@@ -11,7 +11,7 @@ defmodule Emojix.Emoji do
             variations: []
 
   @type t :: %__MODULE__{
-          id: Integer.t(),
+          id: integer(),
           hexcode: String.t(),
           description: String.t(),
           shortcodes: [String.t()],


### PR DESCRIPTION
`Integer.t()` does not exist, use `integer()`